### PR TITLE
refactor(api): dynamically determine base URL from request headers

### DIFF
--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -12,7 +12,10 @@ export async function POST(request: Request) {
     console.log('-- [Received request body] --', body);
     console.log(body);
     const { amount, currency, eventName, quantity, sessionsCount, customerName, customerEmail, customerPhone, appointmentDate, startTime, endTime, locale = 'ru' } = body;
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    // Get the base URL from the request headers to support dynamic domains
+    const host = request.headers.get('host');
+    const protocol = request.headers.get('x-forwarded-proto') || 'https';
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`;
     const successUrl = `${baseUrl}/${locale}/booking/success?session_id={CHECKOUT_SESSION_ID}`;
     const cancelUrl = `${baseUrl}/${locale}/booking?canceled=true`;
 

--- a/app/api/create-session/route.ts
+++ b/app/api/create-session/route.ts
@@ -62,7 +62,12 @@ export async function POST(request: Request) {
     try {
       const sessionEventName = getSessionEventName(event_name, 1, 1, 'ru');
       
-      const calendarResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/add-to-calendar`, {
+      // Dynamically determine the base URL from request headers
+      const host = request.headers.get('host');
+      const protocol = request.headers.get('x-forwarded-proto') || 'http';
+      const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`;
+      
+      const calendarResponse = await fetch(`${baseUrl}/api/add-to-calendar`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/app/api/generate-booking-link/route.ts
+++ b/app/api/generate-booking-link/route.ts
@@ -42,7 +42,10 @@ export async function POST(req: NextRequest) {
       }
     }
     // Construct the booking link
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    // Dynamically determine the base URL from request headers
+    const host = req.headers.get('host');
+    const protocol = req.headers.get('x-forwarded-proto') || 'http';
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`;
     const link = `${baseUrl}/booking/package/${booking_token}`;
     return NextResponse.json({ success: true, link });
   } catch (err) {

--- a/app/api/save-booking/route.ts
+++ b/app/api/save-booking/route.ts
@@ -78,7 +78,12 @@ export async function POST(request: Request) {
 
       // Add event to Google Calendar
       try {
-        const calendarResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/add-to-calendar`, {
+        // Dynamically determine the base URL from request headers
+        const host = request.headers.get('host');
+        const protocol = request.headers.get('x-forwarded-proto') || 'http';
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`;
+        
+        const calendarResponse = await fetch(`${baseUrl}/api/add-to-calendar`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -133,7 +138,12 @@ export async function POST(request: Request) {
 
       // Add event to Google Calendar for regular bookings too
       try {
-        const calendarResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/add-to-calendar`, {
+        // Dynamically determine the base URL from request headers
+        const host = request.headers.get('host');
+        const protocol = request.headers.get('x-forwarded-proto') || 'http';
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${protocol}://${host}`;
+        
+        const calendarResponse = await fetch(`${baseUrl}/api/add-to-calendar`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
Use request headers to construct base URLs instead of relying solely on environment variables. This provides better support for dynamic domains and improves deployment flexibility across different environments.